### PR TITLE
Remove AWS_REGION from tests

### DIFF
--- a/functions/replace-route/tests/test_replace_route.py
+++ b/functions/replace-route/tests/test_replace_route.py
@@ -117,8 +117,6 @@ def test_handler():
         },
     )
 
-    ec2 = boto3.resource("ec2", region_name=AWS_REGION)
-
     from app import handler
 
     script_dir = os.path.dirname(__file__)
@@ -162,8 +160,6 @@ def _process_lambda(func_str):
 @mock_ec2
 @responses.activate
 def test_connectivity_test_handler():
-    ec2 = boto3.resource("ec2", region_name=AWS_REGION)
-    ec2_client = boto3.client("ec2", region_name=AWS_REGION)
     lambda_function_name = "ha-nat-connectivity-test"
     mocked_networking = setup_networking()
 


### PR DESCRIPTION
Refactor proposal because something felt off to me in the way boto is called in `app.py` vs `test_replace_route.py`.

In the former, region is never used as an argument, in the latter it's always there.

`ec2_client = boto3.client("ec2")` vs `ec2_client = boto3.client("ec2", region_name=AWS_REGION)`

But that's not enough to make the tests run, `NoRegionError` is raised by `app.py` when invoking `pytest`.

```
$ pytest 

FAILED test_replace_route.py::test_handler - botocore.exceptions.NoRegionError: You must specify a region.
FAILED test_replace_route.py::test_connectivity_test_handler - botocore.exceptions.NoRegionError: You must specify a region.
```


A simple workaround to make the tests pass is to invoke with `AWS_DEFAULT_REGION`:

```$ AWS_DEFAULT_REGION='us-east-1' pytest```

But if this is the recommended way to run the tests, then we can remove the region argument to boto calls in `test_replace_route.py`

So in this PR, that's what I'm doing. (also removing some unused vars)