### PR TITLE
Restores image build/push workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,27 @@
+name: Build
+
+on: push
+
+jobs:
+  build_and_push_image:
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Set outputs
+        id: sha
+        run: echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Build, tag, and push lambda image to Amazon ECR
+        run: |
+          docker build . -t "${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ steps.sha.outputs.short_sha }}"
+          docker push "${{ secrets.ECR_REGISTRY}}/${{ secrets.ECR_REPOSITORY }}:${{ steps.sha.outputs.short_sha }}"


### PR DESCRIPTION
This was removed in #116 because I thought it was no longer needed, but I had forgotten about the CI issue with the zip file. We're still using the docker approach until I can resolve that, so we need this image for now.