### PR TITLE
Fixes bash issue with parsing with multiple VPC CIDR blocks

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -8,12 +8,26 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 4"
 
-  name               = var.vpc_name
-  cidr               = var.vpc_cidr
-  private_subnets    = var.private_subnets
-  public_subnets     = var.public_subnets
-  azs                = local.azs
-  enable_nat_gateway = var.enable_nat_gateway
+  name                  = var.vpc_name
+  cidr                  = var.vpc_cidrs
+  secondary_cidr_blocks = [var.vpc_secondary_cidr]
+  private_subnets       = var.private_subnets
+  public_subnets        = var.public_subnets
+  azs                   = local.azs
+  enable_nat_gateway    = var.enable_nat_gateway
+}
+
+resource "aws_subnet" "secondary_subnets" {
+  count             = length(var.vpc_secondary_subnets)
+  vpc_id            = module.vpc.vpc_id
+  cidr_block        = var.vpc_secondary_subnets[count.index]
+  availability_zone = local.azs[count.index]
+}
+
+resource "aws_route_table_association" "secondary_subnets" {
+  count          = length(var.vpc_secondary_subnets)
+  subnet_id      = aws_subnet.secondary_subnets[count.index].id
+  route_table_id = module.vpc.private_route_table_ids[count.index]
 }
 
 data "aws_subnet" "subnet" {
@@ -25,9 +39,12 @@ locals {
   vpc_az_maps = [
     for index, rt in module.vpc.private_route_table_ids
     : {
-      az                 = data.aws_subnet.subnet[index].availability_zone
-      route_table_ids    = [rt]
-      public_subnet_id   = module.vpc.public_subnets[index]
+      az               = data.aws_subnet.subnet[index].availability_zone
+      route_table_ids  = [rt]
+      public_subnet_id = module.vpc.public_subnets[index]
+      # The secondary subnets do not need to be included here. this data is
+      # used for the connectivity test function and VPC endpoint which are
+      # only needed in one subnet per zone.
       private_subnet_ids = [module.vpc.private_subnets[index]]
     }
   ]

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -9,7 +9,7 @@ module "vpc" {
   version = "~> 4"
 
   name                  = var.vpc_name
-  cidr                  = var.vpc_cidrs
+  cidr                  = var.vpc_cidr
   secondary_cidr_blocks = [var.vpc_secondary_cidr]
   private_subnets       = var.private_subnets
   public_subnets        = var.public_subnets

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -46,6 +46,18 @@ variable "vpc_cidr" {
   default     = "10.10.0.0/16"
 }
 
+variable "vpc_secondary_subnets" {
+  description = "List of private subnets in the secondary cidr space."
+  type        = list(string)
+  default     = ["10.20.20.0/24", "10.20.21.0/24"]
+}
+
+variable "vpc_secondary_cidr" {
+  description = "A secondary CIDR block to use with the example VPC."
+  type        = string
+  default     = "10.20.0.0/16"
+}
+
 variable "vpc_name" {
   description = "The name to use for the example VPC."
   type        = string

--- a/scripts/alternat.sh
+++ b/scripts/alternat.sh
@@ -47,14 +47,12 @@ configure_nat() {
    local vpc_cidr_uri="http://169.254.169.254/latest/meta-data/network/interfaces/macs/${nic_mac}/vpc-ipv4-cidr-blocks"
    echo "Metadata location for vpc ipv4 ranges: $vpc_cidr_uri"
 
-   local vpc_cidr_ranges=$(CURL_WITH_TOKEN "$vpc_cidr_uri")
-   if [ $? -ne 0 ]; then
+   readarray vpc_cidrs <<< $(CURL_WITH_TOKEN "$vpc_cidr_uri")
+   if [ ${#vpc_cidrs[*]} -lt 1 ]; then
       panic "Unable to obtain VPC CIDR range from metadata."
    else
-      echo "Retrieved VPC CIDR range(s) $vpc_cidr_ranges from metadata."
+      echo "Retrieved VPC CIDR range(s) ${vpc_cidrs[@]} from metadata."
    fi
-
-   IFS=' ' read -r -a vpc_cidrs <<< $(echo "$vpc_cidr_ranges")
 
    echo "Enabling NAT..."
    # Read more about these settings here: https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt

--- a/test/alternat_test.go
+++ b/test/alternat_test.go
@@ -144,6 +144,7 @@ func TestAlternat(t *testing.T) {
 	chain postrouting {
 		type nat hook postrouting priority srcnat; policy accept;
 		ip saddr 10.10.0.0/16 oif "ens5" masquerade
+		ip saddr 10.20.0.0/16 oif "ens5" masquerade
 	}
 }
 `


### PR DESCRIPTION
Fixes an issue introduced in #116 where configurations with multiple VPC CIDR blocks attached to a VPC would result in only one range being added to the NAT table. Connections from clients in the additional VPCs would not be NAT'd.

This is due to a difference in `read` behavior with regard to newlines. AL2 was using bash ~4.3 r46, while AL2023 uses 5.2. Many changes to `IFS` and `read` were made in between releases, and one of those changed the behavior such that the list was not being parsed correctly.

This PR updates the parsing to use `readarray` which does work with the list of CIDR ranges returned from the metadata endpoint. Also updates the test to include a secondary CIDR range on the VPC.