### PR TITLE
feat: use structured logging with structlog

### DIFF
--- a/functions/replace-route/app.py
+++ b/functions/replace-route/app.py
@@ -50,6 +50,8 @@ REQUEST_TIMEOUT = 5
 # Whether or not use IPv6.
 DEFAULT_HAS_IPV6 = True
 
+# Whether or not to log successful connections.
+DEFAULT_LOG_SUCCESSFUL_CONNECTIONS = False
 
 # Overrides socket.getaddrinfo to perform IPv4 lookups
 # See https://github.com/chime/terraform-aws-alternat/issues/87
@@ -150,12 +152,17 @@ def check_connection(check_urls):
     If all fail, replaces the route table to point at a standby NAT Gateway and
     return failure.
     """
+    log_successful_connections = get_env_bool("LOG_SUCCESSFUL_CONNECTIONS", DEFAULT_LOG_SUCCESSFUL_CONNECTIONS)
+
     for url in check_urls:
         try:
             req = urllib.request.Request(url)
             req.add_header('User-Agent', 'alternat/1.0')
             urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT)
-            slogger.debug("Successfully connected to %s", url)
+            if log_successful_connections:
+                slogger.info("Successfully connected to %s", url)
+            else:
+                slogger.debug("Successfully connected to %s", url)
             return True
         except urllib.error.HTTPError as error:
             slogger.warning("Response error from %s: %s, treating as success", url, error)

--- a/functions/replace-route/app.py
+++ b/functions/replace-route/app.py
@@ -186,11 +186,11 @@ def check_connection(check_urls):
 
 def connectivity_test_handler(event, context):
     if not isinstance(event, dict):
-        slogger.error("Unknown event", eventPayload=event)
+        slogger.error("Unknown event: %s", {event})
         return
 
     if event.get("source") != "aws.events":
-        slogger.error("Unable to handle unknown event type", eventPayload=json.dumps(event))
+        slogger.error("Unable to handle unknown event type: %s", json.dumps(event))
         raise UnknownEventTypeError
 
     slogger.debug("Starting NAT instance connectivity test")

--- a/functions/replace-route/requirements.txt
+++ b/functions/replace-route/requirements.txt
@@ -1,1 +1,3 @@
 boto3==1.34.90
+structlog==24.4.0
+orjson==3.10.14

--- a/lambda.tf
+++ b/lambda.tf
@@ -5,6 +5,7 @@ locals {
     : replace(upper(obj.az), "-", "_") => join(",", obj.route_table_ids)
   }
   has_ipv6_env_var = { "HAS_IPV6" = var.lambda_has_ipv6 }
+  log_successful_connections_env_var = { "LOG_SUCCESSFUL_CONNECTIONS" = var.log_successful_connections }
   lambda_runtime   = "python3.12"
 }
 
@@ -161,6 +162,7 @@ resource "aws_lambda_function" "alternat_connectivity_tester" {
         NAT_GATEWAY_ID      = var.nat_gateway_id,
       },
       local.has_ipv6_env_var,
+      local.log_successful_connections_env_var
       var.lambda_environment_variables,
     )
   }

--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,12 @@ variable "lifecycle_heartbeat_timeout" {
   default     = 180
 }
 
+variable "log_successful_connections" {
+  description = "Logs successful connection events during connection checks. This will increase the number of logs produced by the Lambda function in proportion to the number of checks each time the Lambda runs."
+  type        = bool
+  default     = false
+}
+
 variable "max_instance_lifetime" {
   description = "Max instance life in seconds. Defaults to 14 days. Set to 0 to disable."
   type        = number


### PR DESCRIPTION
# Purpose 🎯 

This change adds a configuration option for users to expose successful
connection logs. This is controlled via an environment variable that,
when set to true, will produce the successful connection log as an
`info` level message, rather than a `debug` level message.

Exposing these logs can be useful for calculating SLIs. SLIs are the
quotient of errors over valid requests, therefore all valid messages
need to be surfaced to perform an accurate calculation of the metric.

# Context 🧠 

- Follow up to #122
- Part 2 to satisfy: https://github.com/chime/terraform-aws-alternat/issues/76