### PR TITLE
Triggers workflows on pull_request

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,8 @@
 name: Test
 
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   lambda_tests:


### PR DESCRIPTION
According to [this comment](https://github.com/orgs/community/discussions/50736#discussioncomment-10844546), this may fix the issue I'm having with https://github.com/chime/terraform-aws-alternat/pull/122 where the workflow is not running from the public fork.