### PR TITLE
Fixes deprecation warning, output wording

### DIFF
--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -88,7 +88,7 @@ data "aws_iam_policy_document" "alternat_lambda_permissions" {
     ]
     resources = [
       for route_table in local.all_route_tables
-      : "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
+      : "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
     ]
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 
 output "nat_instance_eips" {
-  description = "List of Elastic IP addresses used by the NAT instances with `prevent_destroy` set. This will be empty if EIPs are provided in var.nat_instance_eip_ids."
+  description = "List of Elastic IP addresses used by the NAT instances. This will be empty if EIPs are provided in var.nat_instance_eip_ids."
   value = (local.reuse_nat_instance_eips
     ? []
   : local.nat_instance_eips[*].public_ip)


### PR DESCRIPTION
Per the docs:
```
[name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region#name-1) - (Optional, Deprecated) Full name of the region to select. Use region instead.
```