### PR TITLE
fix: add fallback for aws_region to support provider < 6.0

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -88,7 +88,7 @@ data "aws_iam_policy_document" "alternat_lambda_permissions" {
     ]
     resources = [
       for route_table in local.all_route_tables
-      : "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
+      : "arn:aws:ec2:${local.aws_region_value}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,8 @@
 ## NAT instance configuration
 locals {
+  # Use region if available (AWS provider v6.x), otherwise fall back to name (AWS provider v5.x)
+  aws_region_value = try(data.aws_region.current.region, data.aws_region.current.name)
+
   initial_lifecycle_hooks = [
     {
       name                    = "NATInstanceTerminationLifeCycleHook"
@@ -396,7 +399,7 @@ data "aws_iam_policy_document" "alternat_ec2_policy" {
     ]
     resources = [
       for route_table in local.all_route_tables
-      : "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
+      : "arn:aws:ec2:${local.aws_region_value}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
     ]
   }
 


### PR DESCRIPTION
### Fix: AWS provider compatibility for `aws_region` data source

#### Background
In v6.0.0 of the AWS provider, `data.aws_region.current.region` was introduced as an alias to `name`.  
However, in provider v5.x (including the supported `>= 5.32.0`), `region` does **not** exist — only `name` is valid.

#### Problem
The module currently uses `data.aws_region.current.region`, which breaks with:
```hcl

│ Error: Unsupported attribute
│ 
│   on .terraform/modules/alternat_instances/lambda.tf line 91, in data "aws_iam_policy_document" "alternat_lambda_permissions":
│   91:       : "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
│ 
│ This object has no argument, nested block, or exported attribute named "region".
╵
```