### PR TITLE
fix: unable to create IAM policy when AlterNAT is deployed in several regions

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -262,13 +262,19 @@ data "aws_iam_policy_document" "lambda_ssm_send_command_document" {
 }
 
 resource "aws_iam_policy" "lambda_ssm_send_command_policy" {
-  count  = var.enable_nat_restore ? 1 : 0
+  count = var.enable_nat_restore && (
+    !var.enable_multi_region.enable || data.aws_region.current.name == var.enable_multi_region.primary_region
+  ) ? 1 : 0
+
   name   = "AllowLambdaToSendSSMCommand"
   policy = data.aws_iam_policy_document.lambda_ssm_send_command_document.json
 }
 
 resource "aws_iam_role_policy_attachment" "attach_lambda_ssm_policy" {
-  count      = var.enable_nat_restore ? 1 : 0
+  count = var.enable_nat_restore && (
+    !var.enable_multi_region.enable || data.aws_region.current.name == var.enable_multi_region.primary_region
+  ) ? 1 : 0
+
   role       = aws_iam_role.nat_lambda_role.name
   policy_arn = aws_iam_policy.lambda_ssm_send_command_policy[0].arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,17 @@ variable "enable_nat_restore" {
   default     = false
 }
 
+variable "enable_multi_region" {
+  type = object({
+    enable         = bool
+    primary_region = string
+  })
+  default = {
+    enable         = false
+    primary_region = "us-east-1"
+  }
+}
+
 variable "ingress_security_group_ids" {
   description = "A list of security group IDs that are allowed by the NAT instance."
   type        = list(string)


### PR DESCRIPTION
When deploying the modules in several regions, I'm getting this error:

```
│ Error: creating IAM Policy (AllowLambdaToSendSSMCommand): operation error IAM: CreatePolicy, https response error StatusCode: 409, RequestID: 03aeb714-9578-4841-93da-794819b4fd66, EntityAlreadyExists: A policy called AllowLambdaToSendSSMCommand already exists. Duplicate names are not allowed.
│ 
```