### PR TITLE
fix: add missing volume tags propagation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -267,6 +267,13 @@ resource "aws_launch_template" "nat_instance_template" {
     })
   }
 
+  tag_specifications {
+    resource_type = "volume"
+
+    tags = merge(var.tags, {
+      alterNATInstance = "true",
+    })
+  }
   user_data = data.cloudinit_config.config[each.key].rendered
 }
 


### PR DESCRIPTION
This pull request adds a new tag specification to the `aws_launch_template` resource for NAT instances in `main.tf`. The change ensures that all EBS volumes created by this launch template are tagged consistently.

Tagging improvements:

* Added a `tag_specifications` block to `aws_launch_template.nat_instance_template` to apply merged tags (including `alterNATInstance = "true"`) to attached EBS volumes.