### PR TITLE
get_nat_gateway_id: Only consider available nat gateways

### DIFF
--- a/functions/replace-route/app.py
+++ b/functions/replace-route/app.py
@@ -104,6 +104,10 @@ def get_nat_gateway_id(vpc_id, subnet_id):
                     "Name": "subnet-id",
                     "Values": [subnet_id]
                 },
+                {
+                    "Name": "state",
+                    "Values": ["available"]
+                }
             ]
         )
     except botocore.exceptions.ClientError as error:


### PR DESCRIPTION
Something we noticed when migrating from AWS managed NAT. The replace route function would try to replace onto an old "deleted" NAT gateway.

Additionally, it might be useful to filter based on resource tag.