### PR TITLE
Treat all http codes < 500 as success

### DIFF
--- a/functions/replace-route/app.py
+++ b/functions/replace-route/app.py
@@ -256,7 +256,7 @@ def attempt_nat_instance_restore():
         if invocation['Status'] == "Success":
             output = invocation['StandardOutputContent'].strip()
             http_codes = output.splitlines()
-            if all(code == "200" for code in http_codes):
+            if all(int(code) < 500 for code in http_codes):
                 logger.info("NAT instance has Internet access, we can diagnose the NAT configuration.")
                 try:
                     if not run_nat_instance_diagnostics(nat_instance_id):


### PR DESCRIPTION
Any http code < 400 is a success code (e.g. 302 redirect), thus should be treated as such. Most non-success http codes (e.g. 404) would also work for checking internet connectivity availability, as there still has to be a server reachable that returns the http code.