### PR TITLE
fix: add conntrack-tools

### DIFF
--- a/scripts/alternat.sh
+++ b/scripts/alternat.sh
@@ -35,7 +35,7 @@ validate_var() {
 # configure_nat() sets up Linux to act as a NAT device.
 # See https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html#NATInstance
 configure_nat() {
-   dnf -y install nftables
+   dnf -y install nftables conntrack-tools
    systemctl enable --now nftables
 
    local nic_name="$(ip route show | grep default | sed -n 's/.*dev \([^\ ]*\).*/\1/p')"


### PR DESCRIPTION
This pull request makes a minor update to the `configure_nat()` function in the `scripts/alternat.sh` script. The change ensures that the necessary `conntrack-tools` package is installed alongside `nftables`, which may be required for proper NAT functionality.

- Added installation of `conntrack-tools` alongside `nftables` in the `configure_nat()` function to support NAT configuration.