### PR TITLE
Fix example and warnings

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -39,7 +39,7 @@ locals {
   vpc_az_maps = [
     for index, rt in module.vpc.private_route_table_ids
     : {
-      az               = data.aws_subnet.subnet[index].availability_zone
+      az               = local.azs[index]
       route_table_ids  = [rt]
       public_subnet_id = module.vpc.public_subnets[index]
       # The secondary subnets do not need to be included here. this data is

--- a/lambda.tf
+++ b/lambda.tf
@@ -88,7 +88,7 @@ data "aws_iam_policy_document" "alternat_lambda_permissions" {
     ]
     resources = [
       for route_table in local.all_route_tables
-      : "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
+      : "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
     ]
   }
 }
@@ -227,7 +227,7 @@ data "aws_iam_policy_document" "lambda_ssm_send_command_document" {
     ]
 
     resources = [
-      "arn:aws:ssm:${data.aws_region.current.name}::document/AWS-RunShellScript",
+      "arn:aws:ssm:${data.aws_region.current.id}::document/AWS-RunShellScript",
     ]
   }
   statement {
@@ -239,7 +239,7 @@ data "aws_iam_policy_document" "lambda_ssm_send_command_document" {
     ]
 
     resources = [
-      "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:instance/*"
+      "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.id}:instance/*"
     ]
     condition {
       test     = "StringEquals"

--- a/main.tf
+++ b/main.tf
@@ -401,7 +401,7 @@ data "aws_iam_policy_document" "alternat_ec2_policy" {
     ]
     resources = [
       for route_table in local.all_route_tables
-      : "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
+      : "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.id}:route-table/${route_table}"
     ]
   }
 


### PR DESCRIPTION
Fix the failing of the `example/` deployment the issue that was talked about in https://github.com/chime/terraform-aws-alternat/issues/104.

Also update a few lines to use the `id` property of AWS Regions instead of the deprecated `name` and get rid of the warnings.

A new users first interaction with this project is most likely going to be via the example deployment, as such I believe it's important to be working out of the box.