### PR TITLE
Install SSM Agent when enable_ssm=true

### DIFF
--- a/alternat.conf.tftpl
+++ b/alternat.conf.tftpl
@@ -2,3 +2,4 @@
 USERDATA_CONFIG_FILE="/etc/alternat.conf"
 echo eip_allocation_ids_csv=${eip_allocation_ids_csv} >> "$USERDATA_CONFIG_FILE"
 echo route_table_ids_csv=${route_table_ids_csv} >> "$USERDATA_CONFIG_FILE"
+echo enable_ssm=${enable_ssm} >> "$USERDATA_CONFIG_FILE"

--- a/main.tf
+++ b/main.tf
@@ -192,7 +192,8 @@ data "cloudinit_config" "config" {
     content_type = "text/x-shellscript"
     content = templatefile("${path.module}/alternat.conf.tftpl", {
       eip_allocation_ids_csv = join(",", local.nat_instance_eip_ids),
-      route_table_ids_csv    = join(",", each.value)
+      route_table_ids_csv    = join(",", each.value),
+      enable_ssm             = var.enable_ssm
     })
   }
 


### PR DESCRIPTION
The SSM Agent is not pre-installed on the AL2023 Minimal AMI so install it via the userscript when '`enable_ssm`' is set to true.

This PR builds on top of https://github.com/chime/terraform-aws-alternat/pull/153 and is recommended to get merged shortly afterwards in order to preserve the current default behaviour.