### PR TITLE
Bumps required Terraform version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.1"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Alternat uses `nullable` now which is only available in Terraform > 1.1.
