### PR TITLE
Fix #174: Use example.edu for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The purpose of [the replace-route Lambda Function](functions/replace-route) is t
 
 When a NAT instance in any of the zonal ASGs is terminated, the lifecycle hook publishes an event to an SNS topic to which the Lambda function is subscribed. The Lambda then performs the necessary steps to identify which zone is affected and updates the respective private route table to point at its standby NAT gateway.
 
-The replace-route function also acts as a health check. Every minute, in the private subnet of each availability zone, the function checks that connectivity to the Internet works by requesting https://www.example.com and, if that fails, https://www.google.com. If the request succeeds, the function exits. If both requests fail, the NAT instance is presumably borked, and the function updates the route to point at the standby NAT gateway.
+The replace-route function also acts as a health check. Every minute, in the private subnet of each availability zone, the function checks that connectivity to the Internet works by requesting https://www.example.edu and, if that fails, https://www.google.com. If the request succeeds, the function exits. If both requests fail, the NAT instance is presumably borked, and the function updates the route to point at the standby NAT gateway.
 
 In the event that a NAT instance is unavailable, the function would have no route to the AWS EC2 API to perform the necessary steps to update the route table. This is mitigated by the use of an [interface VPC endpoint](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/interface-vpc-endpoints.html) to EC2.
 

--- a/functions/replace-route/app.py
+++ b/functions/replace-route/app.py
@@ -25,7 +25,7 @@ LIFECYCLE_ACTION_TOKEN_KEY = "LifecycleActionToken"
 DEFAULT_CONNECTIVITY_CHECK_INTERVAL = "5"
 
 # Which URLs to check for connectivity
-DEFAULT_CHECK_URLS = ["https://www.example.com", "https://www.google.com"]
+DEFAULT_CHECK_URLS = ["https://www.example.edu", "https://www.google.com"]
 
 # The timeout for the connectivity checks.
 REQUEST_TIMEOUT = 5

--- a/functions/replace-route/tests/test_replace_route.py
+++ b/functions/replace-route/tests/test_replace_route.py
@@ -240,7 +240,7 @@ def test_disable_ipv6():
     with mock.patch('socket.getaddrinfo') as mock_getaddrinfo:
         from app import disable_ipv6
         disable_ipv6()
-        socket.getaddrinfo('example.com', 80)
+        socket.getaddrinfo('example.edu', 80)
         mock_getaddrinfo.assert_called()
         call_args = mock_getaddrinfo.call_args.args
         assert len(call_args) == 3, f"With IPv6 disabled, expected 3 arguments to getaddrinfo, found {len(call_args)}"

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "create_nat_gateways" {
 variable "connectivity_test_check_urls" {
   description = "List of URLs to check with the connectivity tester function."
   type        = list(string)
-  default     = ["https://www.example.com", "https://www.google.com"]
+  default     = ["https://www.example.edu", "https://www.google.com"]
 }
 
 variable "connectivity_test_event_rule_name" {


### PR DESCRIPTION
Currently the TLS certificate chains for the example sites served by Cloudflare (.com, .net and .org) contain an invalid root CA cert. This is documented in more detail in both
https://github.com/chime/terraform-aws-alternat/issues/174 and https://community.cloudflare.com/t/cloudflare-ssl-trust-chain-ends-with-invalid-root-ca-aaa-cerificate-services/843576.

The possible workarounds:
- disable certificate checking
- install the missing CA cert on the NAT Instances
- use another domain

Opted to use the third option.
The 'example.edu' domain is an alternative domain that's served by a different provider and uses a different certificate chain. It is also referenced on Wikipedia as an alternative domain reserved for the same purpose: https://en.wikipedia.org/wiki/Example.com