### PR TITLE
Add notification support with email support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,42 @@ Note that the route recovery feature does _not_ attempt to remediate any configu
 
 Also, under certain edge cases, this can potentially lead to flapping between NAT Gateway => NAT Instance => NAT Gateway => NAT Instance. Imagine a scenario where `curl` commands succeed from the NAT instance, and it appears to be configured correctly, so the NAT instance route is restored. But in actuality, a missing security group rule prevents traffic from reaching the NAT instance. During every connectivity check interval, the Lambda will update the route to use the instance since it appears healthy, but then the regular connectivity checks fail due to the missing security group rule, so the Lambda will immediately replace the route again pointing at NAT Gateway. This can happen until the security group rule is fixed.
 
+### Notifications
+
+When notifications are enabled (`enable_notifications=true`), alterNAT will send alerts whenever key events occur, such as:
+
+- Failover to NAT Gateway due to either health-check failure or instance refresh
+- Failback to NAT Instance
+
+Notification messages include information about the affected AWS account, region, Lambda function, and a description of the event.  
+This helps operations teams respond quickly to failures or unexpected conditions.
+
+Notifications are sent via [Amazon SNS](https://aws.amazon.com/sns/).
+
+#### Email notifications
+
+To enable email notifications:
+- Set `enable_notifications=true` in your variables.
+- Subscribe email addresses by setting `notification_email_addresses` to an array of addresses in your variables.  
+For example:
+```hcl
+    notification_email_addresses = ["email-1@example.com", "email-2@example.com"]
+```
+
+Example SNS notification message:
+
+```
+Subject: alterNAT: Failover to standby NAT Gateway
+
+Account ID: 123456789012
+Region: us-west-2
+Function Name: alternat-connectivity-tester-us-west-2a
+
+alterNAT is performing a failover to standby nat gateway for route table rtb-0123456789abcd
+```
+
+Notifications make it easier to monitor the status of your NAT instance fleet and react to failures or health check flapping events.
+
 ## Drawbacks
 
 No solution is without its downsides. To understand the primary drawback of this design, a brief discussion about how NAT works is warranted.

--- a/functions/replace-route/app.py
+++ b/functions/replace-route/app.py
@@ -126,8 +126,12 @@ def get_nat_gateway_id(vpc_id, subnet_id):
 def replace_route(route_table_id, target_id):
     new_route_table = {}
     target_key = "NatGatewayId"
+    notification_subject = "Failover to standby NAT Gateway"
+    notification_message = notification_subject.lower()
     if target_id.startswith("i-"):
         target_key = "InstanceId"
+        notification_subject = "Failback to NAT Instance"
+        notification_message = notification_subject.lower()
     new_route_table = {
         "DestinationCidrBlock": "0.0.0.0/0",
         target_key: target_id,
@@ -136,6 +140,8 @@ def replace_route(route_table_id, target_id):
 
     try:
         logger.info("Replacing existing route %s for route table %s", route_table_id, new_route_table)
+        notification_message = f"alterNAT is performing a {notification_message} for route table {route_table_id}"
+        send_notification(notification_subject, notification_message)
         ec2_client.replace_route(**new_route_table)
     except botocore.exceptions.ClientError as error:
         logger.error("Unable to replace route")
@@ -381,6 +387,19 @@ def get_env_bool(var_name, default_value=False):
     true_values = ["t", "true", "y", "yes", "1"]
     return str(value).lower() in true_values
 
+# Sends a notification to the SNS topic.
+def send_notification(subject, message):
+    if topic_arn := os.getenv("NOTIFICATION_TOPIC_ARN"):
+        account_id = os.getenv('AWS_ACCOUNT_ID')
+        region = os.getenv('AWS_REGION')
+        function_name = os.getenv('AWS_LAMBDA_FUNCTION_NAME')
+        message = f"Account ID: {account_id}\nRegion: {region}\nFunction Name: {function_name}\n\n{message}"
+        sns_client = boto3.client("sns")
+        sns_client.publish(
+            TopicArn=topic_arn,
+            Subject=f"alterNAT: {subject}",
+            Message=message,
+        )
 
 def complete_asg_lifecycle_action(
     auto_scaling_group_name,

--- a/lambda.tf
+++ b/lambda.tf
@@ -36,8 +36,12 @@ resource "aws_lambda_function" "alternat_autoscaling_hook" {
 
   environment {
     variables = merge(
+      {
+        NAT_GATEWAY_ID         = var.nat_gateway_id
+        NOTIFICATION_TOPIC_ARN = var.enable_notifications ? aws_sns_topic.notification_topic[0].arn : null
+        AWS_ACCOUNT_ID         = var.enable_notifications ? data.aws_caller_identity.current.account_id : null
+      },
       local.autoscaling_func_env_vars,
-      { NAT_GATEWAY_ID = var.nat_gateway_id },
       var.lambda_environment_variables,
     )
   }
@@ -104,6 +108,18 @@ data "aws_iam_policy_document" "alternat_lambda_permissions" {
   }
 }
 
+data "aws_iam_policy_document" "alternat_lambda_notification_permissions" {
+  count = var.enable_notifications ? 1 : 0
+  statement {
+    sid    = "alterNATNotificationPermissions"
+    effect = "Allow"
+    actions = [
+      "sns:Publish",
+    ]
+    resources = [aws_sns_topic.notification_topic[0].arn]
+  }
+}
+
 data "aws_iam_policy_document" "nat_lambda_policy" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -118,6 +134,13 @@ data "aws_iam_policy_document" "nat_lambda_policy" {
 resource "aws_iam_role_policy" "alternat_lambda_permissions" {
   name   = "alternat-lambda-permissions-policy"
   policy = data.aws_iam_policy_document.alternat_lambda_permissions.json
+  role   = aws_iam_role.nat_lambda_role.name
+}
+
+resource "aws_iam_role_policy" "alternat_lambda_notification_permissions" {
+  count  = var.enable_notifications ? 1 : 0
+  name   = "alternat-lambda-notification-permissions-policy"
+  policy = data.aws_iam_policy_document.alternat_lambda_notification_permissions[0].json
   role   = aws_iam_role.nat_lambda_role.name
 }
 
@@ -166,12 +189,14 @@ resource "aws_lambda_function" "alternat_connectivity_tester" {
   environment {
     variables = merge(
       {
-        ROUTE_TABLE_IDS_CSV = join(",", each.value.route_table_ids),
-        PUBLIC_SUBNET_ID    = each.value.public_subnet_id
-        CHECK_URLS          = join(",", var.connectivity_test_check_urls)
-        NAT_GATEWAY_ID      = var.nat_gateway_id
-        NAT_ASG_NAME        = aws_autoscaling_group.nat_instance[each.key].name
-        ENABLE_NAT_RESTORE  = var.enable_nat_restore
+        ROUTE_TABLE_IDS_CSV    = join(",", each.value.route_table_ids),
+        PUBLIC_SUBNET_ID       = each.value.public_subnet_id
+        CHECK_URLS             = join(",", var.connectivity_test_check_urls)
+        NAT_GATEWAY_ID         = var.nat_gateway_id
+        NAT_ASG_NAME           = aws_autoscaling_group.nat_instance[each.key].name
+        ENABLE_NAT_RESTORE     = var.enable_nat_restore
+        NOTIFICATION_TOPIC_ARN = var.enable_notifications ? aws_sns_topic.notification_topic[0].arn : null
+        AWS_ACCOUNT_ID         = var.enable_notifications ? data.aws_caller_identity.current.account_id : null
       },
       local.has_ipv6_env_var,
       var.lambda_environment_variables,

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,18 @@ locals {
     }
     : {}
   )
+  sns_endpoint = (
+    var.enable_notifications
+    ? {
+      sns = {
+        service             = "sns"
+        private_dns_enabled = true
+        subnet_ids          = local.az_private_subnets
+        tags                = { Name = "sns-vpc-endpoint" }
+      }
+    }
+    : {}
+  )
 
   # Must provide exactly 1 EIP per AZ
   # var.nat_instance_eip_ids ignored if doesn't match AZ count
@@ -570,10 +582,24 @@ module "vpc_endpoints" {
   version            = "~> 3.14.0"
   vpc_id             = var.vpc_id
   security_group_ids = [aws_security_group.vpc_endpoint[0].id]
-  endpoints          = local.ec2_endpoint
+  endpoints          = merge(local.ec2_endpoint, local.sns_endpoint)
   tags               = var.tags
 }
 
 data "aws_default_tags" "current" {}
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
+
+resource "aws_sns_topic" "notification_topic" {
+  count             = var.enable_notifications ? 1 : 0
+  name_prefix       = var.notification_topic_prefix
+  kms_master_key_id = "alias/aws/sns"
+  tags              = var.tags
+}
+
+resource "aws_sns_topic_subscription" "notification_email_subscription" {
+  count     = var.enable_notifications ? length(var.notification_email_addresses) : 0
+  topic_arn = aws_sns_topic.notification_topic[0].arn
+  protocol  = "email"
+  endpoint  = var.notification_email_addresses[count.index]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -317,3 +317,21 @@ variable "enable_launch_script_lifecycle_hook" {
   type        = bool
   default     = false
 }
+
+variable "enable_notifications" {
+  description = "Whether to enable notifications for failover events."
+  type        = bool
+  default     = false
+}
+
+variable "notification_topic_prefix" {
+  description = "The prefix to use for the name of the notification topic."
+  type        = string
+  default     = "alternat-notifications"
+}
+
+variable "notification_email_addresses" {
+  description = "List of email addresses to send notifications to."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Send notifications via SNS during failover activities.

Feel free to suggest wording for the README and the notifications.