### PR TITLE
feat: propagate tags to network interfaces via launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -314,6 +314,14 @@ resource "aws_launch_template" "nat_instance_template" {
       alterNATInstance = "true",
     })
   }
+
+  tag_specifications {
+    resource_type = "network-interface"
+
+    tags = merge(var.tags, {
+      alterNATInstance = "true",
+    })
+  }
   user_data = data.cloudinit_config.config[each.key].rendered
 }
 


### PR DESCRIPTION
Add tag_specifications for resource_type 'network-interface' to the NAT instance launch template. This ensures tags passed via var.tags are applied to ENIs at launch time, enabling tag-based ENI discovery for cost attribution pipelines.